### PR TITLE
Typo in Configs

### DIFF
--- a/GameData/OrbitalColony/Configs/CLS.cfg
+++ b/GameData/OrbitalColony/Configs/CLS.cfg
@@ -30,7 +30,7 @@
 		passable = true
 	}
 }
-@PART[OrbitalColonyGardenBiosphereLargeMedium]:NEEDS[ConnectedLivingSpace]
+@PART[OrbitalColonyGardenBiosphereMedium]:NEEDS[ConnectedLivingSpace]
 {
 	MODULE
 	{

--- a/GameData/OrbitalColony/Configs/CTT.cfg
+++ b/GameData/OrbitalColony/Configs/CTT.cfg
@@ -14,7 +14,7 @@
 {
     @TechRequired = longTermHabitation
 }
-@PART[OrbitalColonyGardenBiosphereLargeMedium]:NEEDS[CommunityTechTree]
+@PART[OrbitalColonyGardenBiosphereMedium]:NEEDS[CommunityTechTree]
 {
     @TechRequired = shortTermHabitation
 }

--- a/GameData/OrbitalColony/Configs/TACLS.cfg
+++ b/GameData/OrbitalColony/Configs/TACLS.cfg
@@ -319,7 +319,7 @@ RESOURCE
 	}
 }
 
-@PART[OrbitalColonyGardenBiosphereLargeMedium]:NEEDS[TacLifeSupport]
+@PART[OrbitalColonyGardenBiosphereMedium]:NEEDS[TacLifeSupport]
 {
 	MODULE
 	{


### PR DESCRIPTION
The medium garden doesn't receive TACLS patches.
Edit: The same in CLS.cfg and CTT.cfg. I attached a patch. Or do you prefer pull requests?


```
diff --git a/GameData/OrbitalColony/Configs/CLS.cfg b/GameData/OrbitalColony/Configs/CLS.cfg
index 3dbf6b2..9db653a 100644
--- a/GameData/OrbitalColony/Configs/CLS.cfg
+++ b/GameData/OrbitalColony/Configs/CLS.cfg
@@ -30,7 +30,7 @@
 		passable = true
 	}
 }
-@PART[OrbitalColonyGardenBiosphereLargeMedium]:NEEDS[ConnectedLivingSpace]
+@PART[OrbitalColonyGardenBiosphereMedium]:NEEDS[ConnectedLivingSpace]
 {
 	MODULE
 	{
diff --git a/GameData/OrbitalColony/Configs/CTT.cfg b/GameData/OrbitalColony/Configs/CTT.cfg
index 69dbf12..01f35a1 100644
--- a/GameData/OrbitalColony/Configs/CTT.cfg
+++ b/GameData/OrbitalColony/Configs/CTT.cfg
@@ -14,7 +14,7 @@
 {
     @TechRequired = longTermHabitation
 }
-@PART[OrbitalColonyGardenBiosphereLargeMedium]:NEEDS[CommunityTechTree]
+@PART[OrbitalColonyGardenBiosphereMedium]:NEEDS[CommunityTechTree]
 {
     @TechRequired = shortTermHabitation
 }
diff --git a/GameData/OrbitalColony/Configs/TACLS.cfg b/GameData/OrbitalColony/Configs/TACLS.cfg
index 522d41d..d464d90 100644
--- a/GameData/OrbitalColony/Configs/TACLS.cfg
+++ b/GameData/OrbitalColony/Configs/TACLS.cfg
@@ -319,7 +319,7 @@ RESOURCE
 	}
 }
 
-@PART[OrbitalColonyGardenBiosphereLargeMedium]:NEEDS[TacLifeSupport]
+@PART[OrbitalColonyGardenBiosphereMedium]:NEEDS[TacLifeSupport]
 {
 	MODULE
 	{
```
[orbitalcolony_cfgs.diff.txt](https://github.com/linuxgurugamer/KSP-OrbitalColony/files/2953685/orbitalcolony_cfgs.diff.txt)
