### PR TITLE
Added CLS info to passable truss segments

### DIFF
--- a/GameData/OrbitalColony/Configs/CLS.cfg
+++ b/GameData/OrbitalColony/Configs/CLS.cfg
@@ -78,3 +78,43 @@
 		passable = true
 	}
 }
+
+@PART[truss6x6Core]:HAS[!MODULE[ConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false
+		passablenodes = front,back
+	}
+}
+
+@PART[truss6x6CoreL]:HAS[!MODULE[ConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false
+		passablenodes = right,bottom
+	}
+}
+
+@PART[truss6x6CoreT]:HAS[!MODULE[ConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false
+		passablenodes = left,right,bottom
+	}
+}
+
+@PART[truss6x6CoreX]:HAS[!MODULE[ConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false
+		passablenodes = left,right,top,bottom
+	}
+}


### PR DESCRIPTION
From the description, the truss segments with a core should be crew-passable. I added CLS passablenodes options to the core nodes.
